### PR TITLE
Fix `target` / `userlogin` @ parsing issue

### DIFF
--- a/kerberoast/kerberoast.py
+++ b/kerberoast/kerberoast.py
@@ -23,7 +23,7 @@ def from_target_string(target):
 	#get domain, username, password
 	domain = None
 	password = None
-	m = target.find('@')
+	m = target.rfind('@')
 	if m == -1:
 		raise Exception('Failed to find address!')
 	address = target[m+1:]


### PR DESCRIPTION
Greetings,

This simple PR fixes an issue the target's ip address parsing when passwords contain the '@' character.