### PR TITLE
fix packing issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
 	author_email="info@skelsec.com",
 
 	# Packages
-	packages=find_packages(),
+	packages=find_packages(exclude=["tests*"]),
 
 	# Include additional files into the package
 	include_package_data=True,


### PR DESCRIPTION
setup.py deploys the tests folder under the root python path `/usr/lib/python3.10/site-packages/tests` and not under this package one and so conflicts with other packages having the same issue. In general, in production environment, test files should not be pushed, so the cleanest solution would be just to remove/exclude them.

Source: ArchLinux packaging guidelines for Python: https://wiki.archlinux.org/title/Python_package_guidelines#Test_directory_in_site-package