### PR TITLE
fix: msldap requirement fixed to version 0.4.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-msldap>=0.4.7
+msldap==0.4.7
 minikerberos>=0.4.0
 winsspi;platform_system=="Windows"
 winacl>=0.1.1; platform_system=="Windows"


### PR DESCRIPTION
newer versions of the library seem to break the api this tool uses